### PR TITLE
Change source to . (POSIX-compatible)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 dev : .venv
-	@source ./.venv/bin/activate && IRI_SHOW_MISSING_ROUTES=true API_URL_ROOT='http://127.0.0.1:8000' fastapi dev
+	@. ./.venv/bin/activate && IRI_SHOW_MISSING_ROUTES=true API_URL_ROOT='http://127.0.0.1:8000' fastapi dev
 
 
 .venv:


### PR DESCRIPTION
source is not implemented in sh ( the default shell for make ).