### PR TITLE
Make app a namespace package to support adapter overlays

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
This converts the app package into a namespace package. Py implementation supports adapter (facility implementations) that live in other repositories. While it works perfectly inside containers (with COPY...), for development it does not. Without namespace, Python resolves only the first app, making overlay adapters invisible. This change should not affect existing imports or runtime.  With this, here is an example for facility adapter (requirement for app to also use same content as in this file)
```
(cmd)>ls -l
drwxr-xr-x  5 jbalcas  staff   160 Jan 14 09:20 app
(cmd)>ls -l app/
-rw-r--r--  1 jbalcas  staff     75 Jan 14 09:03 __init__.py
-rw-r--r--@ 1 jbalcas  staff  18604 Jan 14 06:05 esnet_adapter.py
```