### PR TITLE
Changed site_url to site_id

### DIFF
--- a/app/demo_adapter.py
+++ b/app/demo_adapter.py
@@ -103,7 +103,7 @@ class DemoAdapter(
             state_or_province_name="DC",
             latitude=36.173357,
             longitude=-234.51452,
-            resource_uris=[],
+            resource_ids=[],
         )
 
         site2 = facility_models.Site(
@@ -118,7 +118,7 @@ class DemoAdapter(
             state_or_province_name="ET",
             latitude=38.410558,
             longitude=-286.36999,
-            resource_uris=[],
+            resource_ids=[],
         )
 
         self.facility = facility_models.Facility(
@@ -129,7 +129,7 @@ class DemoAdapter(
             short_name="DEMO",
             organization_name="Demo Organization",
             support_uri="https://support.demo.example",
-            site_uris=[site1.self_uri, site2.self_uri],
+            site_ids=[site1.id, site2.id],
         )
 
         self.sites = [site1, site2]
@@ -155,7 +155,6 @@ class DemoAdapter(
             current_status=status_models.Status.degraded,
             last_modified=day_ago,
             resource_type=status_models.ResourceType.compute,
-            located_at_uri=site1.self_uri,
         )
 
         hpss = status_models.Resource(
@@ -168,7 +167,6 @@ class DemoAdapter(
             current_status=status_models.Status.up,
             last_modified=day_ago,
             resource_type=status_models.ResourceType.storage,
-            located_at_uri=site1.self_uri,
         )
 
         cfs = status_models.Resource(
@@ -181,7 +179,6 @@ class DemoAdapter(
             current_status=status_models.Status.up,
             last_modified=day_ago,
             resource_type=status_models.ResourceType.storage,
-            located_at_uri=site1.self_uri,
         )
 
         login = status_models.Resource(
@@ -194,7 +191,6 @@ class DemoAdapter(
             current_status=status_models.Status.degraded,
             last_modified=day_ago,
             resource_type=status_models.ResourceType.system,
-            located_at_uri=site2.self_uri,
         )
 
         iris = status_models.Resource(
@@ -207,7 +203,6 @@ class DemoAdapter(
             current_status=status_models.Status.down,
             last_modified=day_ago,
             resource_type=status_models.ResourceType.website,
-            located_at_uri=site2.self_uri,
         )
         sfapi = status_models.Resource(
             id=str(uuid.uuid4()),
@@ -219,10 +214,13 @@ class DemoAdapter(
             current_status=status_models.Status.up,
             last_modified=day_ago,
             resource_type=status_models.ResourceType.service,
-            located_at_uri=site2.self_uri,
         )
 
         self.resources = [pm, hpss, cfs, login, iris, sfapi]
+
+        # Populate site resource_ids based on which resources are at each site
+        site1.resource_ids = [r.id for r in self.resources if r.site_id == site1.id]
+        site2.resource_ids = [r.id for r in self.resources if r.site_id == site2.id]
 
         self.projects = [
             account_models.Project(

--- a/app/routers/facility/models.py
+++ b/app/routers/facility/models.py
@@ -1,9 +1,10 @@
 """Facility-related models."""
 
-from typing import List, Optional
+from typing import Optional
 
-from pydantic import Field, HttpUrl
+from pydantic import Field, HttpUrl, computed_field
 
+from ... import config
 from ...types.base import NamedObject
 
 
@@ -21,7 +22,13 @@ class Site(NamedObject):
     altitude: Optional[float] = Field(None, description="Altitude of the Location.")
     latitude: Optional[float] = Field(None, description="Latitude of the Location.")
     longitude: Optional[float] = Field(None, description="Longitude of the Location.")
-    resource_uris: List[HttpUrl] = Field(default_factory=list, description="URIs of Resources hosted at this Site.")
+    resource_ids: list[str] = Field(default_factory=list, exclude=True)
+
+    @computed_field(description="URIs of Resources hosted at this Site.")
+    @property
+    def resource_uris(self) -> list[str]:
+        """Return the list of resource URIs for this site."""
+        return [f"{config.API_URL_ROOT}{config.API_PREFIX}{config.API_URL}/status/resources/{resource_id}" for resource_id in self.resource_ids]
 
     @classmethod
     def find(cls, items, name=None, description=None, modified_since=None, short_name=None, country_name=None):
@@ -39,6 +46,12 @@ class Facility(NamedObject):
         return "/facility"
 
     short_name: Optional[str] = Field(None, description="Common or short name of the Facility.")
-    organization_name: Optional[str] = Field(None, description="Operating organization’s name.")
+    organization_name: Optional[str] = Field(None, description="Operating organization's name.")
     support_uri: Optional[HttpUrl] = Field(None, description="Link to facility support portal.")
-    site_uris: List[HttpUrl] = Field(default_factory=list, description="URIs of associated Sites.")
+    site_ids: list[str] = Field(default_factory=list, exclude=True)
+
+    @computed_field(description="URIs of associated Sites.")
+    @property
+    def site_uris(self) -> list[str]:
+        """Return the list of site URIs for this facility."""
+        return [f"{config.API_URL_ROOT}{config.API_PREFIX}{config.API_URL}/facility/sites/{site_id}" for site_id in self.site_ids]

--- a/app/routers/status/models.py
+++ b/app/routers/status/models.py
@@ -1,8 +1,7 @@
 import datetime
 import enum
-from typing import Optional
 
-from pydantic import BaseModel, Field, HttpUrl, computed_field, field_validator
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 from ... import config
 from ...types.base import NamedObject
@@ -35,14 +34,17 @@ class Resource(NamedObject):
         """Return the API path for this resource."""
         return f"/status/resources/{self.id}"
 
-    # NOTE (TBR): If site_id is required, then located_at_uri should be also required. This can be easily identified by Site.self_uri
-    # Is there a specific Resource, that has no Site?
-    site_id: str = Field(..., description="The site identifier this resource is located at")
+    site_id: str = Field(..., description="The site identifier this resource is located at", exclude=True)
     capability_ids: list[str] = Field(default_factory=list, exclude=True)
     group: str | None
     current_status: Status | None = Field(default=None, description="The current status comes from the status of the last event for this resource")
     resource_type: ResourceType
-    located_at_uri: Optional[HttpUrl] = Field(None, description="Resource located at specific Site")
+
+    @computed_field(description="URI of the site where this resource is located")
+    @property
+    def site_uri(self) -> str:
+        """Return the site URI for this resource."""
+        return f"{config.API_URL_ROOT}{config.API_PREFIX}{config.API_URL}/facility/sites/{self.site_id}"
 
     @computed_field(description="The list of capabilities in this resource")
     @property


### PR DESCRIPTION
This PR changes some uri-s to id-s to use the same pattern for relationships as elsewhere in the code. The main benefits of this are:
- same coding pattern everywhere
- moves uri creation up into common code
- makes it easier for adapters to deal with objects (via id-s)