### PR TITLE
compute/filesystem report their supported resources

### DIFF
--- a/app/demo_adapter.py
+++ b/app/demo_adapter.py
@@ -180,6 +180,7 @@ class DemoAdapter(
             current_status=status_models.Status.degraded,
             last_modified=day_ago,
             resource_type=status_models.ResourceType.compute,
+            supported_endpoints=[status_models.Endpoint.compute],
         )
 
         hpss = status_models.Resource(
@@ -192,6 +193,7 @@ class DemoAdapter(
             current_status=status_models.Status.up,
             last_modified=day_ago,
             resource_type=status_models.ResourceType.storage,
+            supported_endpoints=[status_models.Endpoint.filesystem],
         )
 
         cfs = status_models.Resource(
@@ -204,6 +206,7 @@ class DemoAdapter(
             current_status=status_models.Status.up,
             last_modified=day_ago,
             resource_type=status_models.ResourceType.storage,
+            supported_endpoints=[status_models.Endpoint.filesystem],
         )
 
         login = status_models.Resource(
@@ -412,6 +415,9 @@ class DemoAdapter(
 
     async def get_resource(self: "DemoAdapter", id_: str) -> status_models.Resource:
         return status_models.Resource.find_by_id(self.resources, id_)
+
+    async def get_resources_for_endpoint(self: "DemoAdapter", endpoint: status_models.Endpoint) -> list[status_models.Resource]:
+        return [r for r in self.resources if endpoint in r.supported_endpoints]
 
     async def get_events(
         self: "DemoAdapter",

--- a/app/routers/compute/compute.py
+++ b/app/routers/compute/compute.py
@@ -24,7 +24,7 @@ router = iri_router.IriRouter(
     response_model_exclude_unset=True,
     responses=DEFAULT_RESPONSES,
     operation_id="getComputeResources",
-    openapi_extra=iri_meta_dict("production", "required"),
+    openapi_extra=iri_meta_dict("planned"),
 )
 async def get_resources(
     request: Request,

--- a/app/routers/compute/compute.py
+++ b/app/routers/compute/compute.py
@@ -8,7 +8,7 @@ from ...types.user import User
 from .. import iri_router
 from ..error_handlers import DEFAULT_RESPONSES
 from ..iri_meta import iri_meta_dict
-from ..status.status import router as status_router
+from ..status.status import router as status_router, models as status_models
 from . import facility_adapter, models
 
 router = iri_router.IriRouter(
@@ -16,6 +16,22 @@ router = iri_router.IriRouter(
     prefix="/compute",
     tags=["compute"],
 )
+
+
+@router.get(
+    "/resources",
+    response_model=list[status_models.Resource],
+    response_model_exclude_unset=True,
+    responses=DEFAULT_RESPONSES,
+    operation_id="getComputeResources",
+    openapi_extra=iri_meta_dict("production", "required"),
+)
+async def get_resources(
+    request: Request,
+    _forbid=Depends(forbidExtraQueryParams()),
+):
+    """Get a list of resources that can be used in this endpoint"""
+    return await status_router.adapter.get_resources_for_endpoint(status_models.Endpoint.compute)
 
 
 @router.post(

--- a/app/routers/filesystem/filesystem.py
+++ b/app/routers/filesystem/filesystem.py
@@ -7,6 +7,7 @@
 import base64
 from typing import Annotated
 from fastapi import Depends, HTTPException, status, Query, Request, File, UploadFile
+from ...types.http import forbidExtraQueryParams
 from ...types.user import User
 from .. import iri_router
 from ..error_handlers import DEFAULT_RESPONSES
@@ -22,6 +23,22 @@ router = iri_router.IriRouter(
     prefix="/filesystem",
     tags=["filesystem"],
 )
+
+
+@router.get(
+    "/resources",
+    response_model=list[status_models.Resource],
+    response_model_exclude_unset=True,
+    responses=DEFAULT_RESPONSES,
+    operation_id="getFilesystemResources",
+    openapi_extra=iri_meta_dict("production", "required"),
+)
+async def get_resources(
+    request: Request,
+    _forbid=Depends(forbidExtraQueryParams()),
+):
+    """Get a list of resources that can be used in this endpoint"""
+    return await status_router.adapter.get_resources_for_endpoint(status_models.Endpoint.filesystem)
 
 
 async def _user_resource(
@@ -250,7 +267,7 @@ async def get_ls_async(
         user=user,
         resource=resource,
         task=task_models.TaskCommand(
-            router=router.get_router_name(), 
+            router=router.get_router_name(),
             command="ls",
             args={"path": path, "show_hidden": show_hidden, "numeric_uid": numeric_uid, "recursive": recursive, "dereference": dereference}
         ),

--- a/app/routers/filesystem/filesystem.py
+++ b/app/routers/filesystem/filesystem.py
@@ -31,7 +31,7 @@ router = iri_router.IriRouter(
     response_model_exclude_unset=True,
     responses=DEFAULT_RESPONSES,
     operation_id="getFilesystemResources",
-    openapi_extra=iri_meta_dict("production", "required"),
+    openapi_extra=iri_meta_dict("planned"),
 )
 async def get_resources(
     request: Request,

--- a/app/routers/status/facility_adapter.py
+++ b/app/routers/status/facility_adapter.py
@@ -21,11 +21,15 @@ class FacilityAdapter(ABC):
         description: str | None = None,
         group: str | None = None,
         modified_since: datetime.datetime | None = None,
-        resource_type: status_models.ResourceType|None = None,
-        current_status: status_models.Status|None = None,
+        resource_type: status_models.ResourceType | None = None,
+        current_status: status_models.Status | None = None,
         capability: Capability | None = None,
         site_id: str | None = None,
     ) -> list[status_models.Resource]:
+        pass
+
+    @abstractmethod
+    async def get_resources_for_endpoint(self: "FacilityAdapter", endpoint: status_models.Endpoint) -> list[status_models.Resource]:
         pass
 
     @abstractmethod

--- a/app/routers/status/models.py
+++ b/app/routers/status/models.py
@@ -27,6 +27,11 @@ class ResourceType(enum.Enum):
     unknown = "unknown"
 
 
+class Endpoint(enum.Enum):
+    compute = "compute"
+    filesystem = "filesystem"
+
+
 class Resource(NamedObject):
     """Represents a resource in the system."""
     def _self_path(self) -> str:
@@ -38,6 +43,7 @@ class Resource(NamedObject):
     group: str|None = Field(default=None, description="Logical grouping of the resource", example="frontend")
     current_status: Status|None = Field(default=None, description="The current status comes from the status of the last event for this resource", example="up")
     resource_type: ResourceType = Field(..., description="Type of the resource", example="service")
+    supported_endpoints: list[Endpoint] = Field(default_factory=list, description="a list of endpoints where this resource can be used")
 
     @computed_field(description="URI of the site where this resource is located")
     @property


### PR DESCRIPTION
- new field called `supported_endpoints` on a `Resource`
- new endpoints: /compute/resources and /filesystem/resources to report which resources can be used to submit actions