### PR TITLE
[Feat] Add idempotency for submit and update job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ $(STAMP_DEPS): $(STAMP_VENV) pyproject.toml
 	$(UV) pip install --python $(BIN)/python \
 		ruff \
 		pylint \
-		bandit
+		bandit \
+		pytest
 	touch $(STAMP_DEPS)
 
 deps: $(STAMP_DEPS)
@@ -45,8 +46,29 @@ dev: deps
 	OPENTELEMETRY_ENABLED=true \
 	API_URL_ROOT='http://localhost:8000' fastapi dev
 
+REDIS_PORT      ?= 6379
+REDIS_CONTAINER := iri-redis
+
+redis: ## Start a local Redis container for idempotency (dev only)
+	docker run -d --name $(REDIS_CONTAINER) -p $(REDIS_PORT):6379 redis:7-alpine 2>/dev/null || \
+		docker start $(REDIS_CONTAINER) 2>/dev/null || true
+	@echo "Redis running on localhost:$(REDIS_PORT)"
+	@echo "Add to local.env:"
+	@echo "  export REDIS_URL=redis://localhost:$(REDIS_PORT)"
+	@echo "  export IDEMPOTENCY_TTL_SECONDS=86400  # cache TTL (default: 24h)"
+	@echo "  export LOCK_TTL_SECONDS=60            # in-flight lock TTL (default: 60s)"
+
+redis-stop: ## Stop the local Redis container
+	docker stop $(REDIS_CONTAINER) 2>/dev/null || true
+
+redis-clean: ## Stop and remove the local Redis container
+	docker rm -f $(REDIS_CONTAINER) 2>/dev/null || true
+
+
+test: deps ## Run unit tests
+	$(BIN)/python -m pytest test/ -v
+
 .PHONY: clean
-clean:
 	rm -rf iri_sandbox
 	rm -rf .venv
 

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ test: deps ## Run unit tests
 	$(BIN)/python -m pytest test/ -v
 
 .PHONY: clean
+clean:
 	rm -rf iri_sandbox
 	rm -rf .venv
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,46 @@ Logs always go to stdout. Optionally, logs can also be written to a rotating fil
 
 For local development, `make` writes logs to `runtime-logs.log` by default and keeps `5` daily rotated files. Use `make LOG_FILE=/tmp/iri-api.log`, `make IRI_LOG_FILE=/tmp/iri-api.log`, or `make LOG_ROTATION_DAYS=10` to override those defaults. You can also put the same variables in `local.env`.
 
+## Idempotency
+
+Compute `submit_job` and `update_job` endpoints support an optional `Idempotency-Key` request header. When provided, the server caches the first successful response for that key and returns it on any subsequent request with the same key and body — without calling the facility adapter again. This makes it safe for clients to retry on timeout without risking duplicate job submissions.
+
+### Behaviour
+
+| Scenario | Response |
+|---|---|
+| First request | Calls adapter, caches result. Response header: `Idempotency-Key-Reply: miss` |
+| Retry, same body | Returns cached result. Response header: `Idempotency-Key-Reply: hit` |
+| Retry, different body | `422 Unprocessable Entity` |
+| Concurrent duplicate (in-flight) | `409 Conflict` with `Retry-After: 2` |
+| Adapter raises | Lock released; client may retry safely |
+
+### Backing store
+
+| `REDIS_URL` set? | Store used | Suitable for |
+|---|---|---|
+| No (default) | In-process dict | Dev / single-instance |
+| Yes | Redis | Multi-replica production |
+
+For multi-replica deployments, Redis is required. Run a local Redis instance with `make redis`.
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `REDIS_URL` | _(unset)_ | Redis connection URL (e.g. `redis://localhost:6379`). When unset, uses in-memory store. |
+| `IDEMPOTENCY_TTL_SECONDS` | `86400` | How long a cached response is retained after a successful call (24 hours). |
+| `LOCK_TTL_SECONDS` | `60` | Maximum seconds an in-flight request holds the lock. If the IRI process crashes mid-request, the lock auto-expires after this interval so the next retry is treated as a fresh request. Set higher if your facility's scheduler API is known to be slow. |
+
+### Quick start (dev)
+
+```bash
+make redis                          # start Redis container on :6379
+# add to local.env:
+export REDIS_URL=redis://localhost:6379
+make                                # start IRI dev server
+```
+
 ## Docker support
 
 You can either use the docker images created on github.com or build the image yourself.

--- a/app/config.py
+++ b/app/config.py
@@ -49,6 +49,13 @@ OTEL_TRACES_ENABLED = os.environ.get("OTEL_TRACES_ENABLED", "true").lower() == "
 OTEL_METRICS_ENABLED = os.environ.get("OTEL_METRICS_ENABLED", "true").lower() == "true"
 OTEL_METRIC_EXPORT_INTERVAL = int(os.environ.get("OTEL_METRIC_EXPORT_INTERVAL", "60000"))
 
+# Idempotency store
+# If unset: in-process dict (single-instance, lost on restart).
+# If set: Redis-backed (multi-replica safe). Install extras: pip install -e ".[redis]"
+REDIS_URL = os.environ.get("REDIS_URL", "")
+IDEMPOTENCY_TTL_SECONDS = int(os.environ.get("IDEMPOTENCY_TTL_SECONDS", "86400"))
+LOCK_TTL_SECONDS = int(os.environ.get("LOCK_TTL_SECONDS", "60"))
+
 # Print all startup config for debugging
 logger.info("IRI Facility API starting with config:")
 logger.info("="*40)
@@ -65,4 +72,7 @@ logger.info(f"OTEL_SAMPLE_RATE={OTEL_SAMPLE_RATE}")
 logger.info(f"OTEL_TRACES_ENABLED={OTEL_TRACES_ENABLED}")
 logger.info(f"OTEL_METRICS_ENABLED={OTEL_METRICS_ENABLED}")
 logger.info(f"OTEL_METRIC_EXPORT_INTERVAL={OTEL_METRIC_EXPORT_INTERVAL}")
+logger.info(f"REDIS_URL={'(set)' if REDIS_URL else '(unset, using in-memory store)'}")
+logger.info(f"IDEMPOTENCY_TTL_SECONDS={IDEMPOTENCY_TTL_SECONDS}")
+logger.info(f"LOCK_TTL_SECONDS={LOCK_TTL_SECONDS}")
 logger.info("="*40)

--- a/app/config.py
+++ b/app/config.py
@@ -50,9 +50,9 @@ OTEL_METRICS_ENABLED = os.environ.get("OTEL_METRICS_ENABLED", "true").lower() ==
 OTEL_METRIC_EXPORT_INTERVAL = int(os.environ.get("OTEL_METRIC_EXPORT_INTERVAL", "60000"))
 
 # Idempotency store
-# If unset: in-process dict (single-instance, lost on restart).
-# If set: Redis-backed (multi-replica safe). Install extras: pip install -e ".[redis]"
-REDIS_URL = os.environ.get("REDIS_URL", "")
+# IRI_IDEMPOTENCY_STORE: fully-qualified class to use as the backing store.
+#   Example: IRI_IDEMPOTENCY_STORE=app.demo_adapter.DemoRedisIdempotencyStore
+IRI_IDEMPOTENCY_STORE = os.environ.get("IRI_IDEMPOTENCY_STORE", "")
 IDEMPOTENCY_TTL_SECONDS = int(os.environ.get("IDEMPOTENCY_TTL_SECONDS", "86400"))
 LOCK_TTL_SECONDS = int(os.environ.get("LOCK_TTL_SECONDS", "60"))
 
@@ -72,7 +72,7 @@ logger.info(f"OTEL_SAMPLE_RATE={OTEL_SAMPLE_RATE}")
 logger.info(f"OTEL_TRACES_ENABLED={OTEL_TRACES_ENABLED}")
 logger.info(f"OTEL_METRICS_ENABLED={OTEL_METRICS_ENABLED}")
 logger.info(f"OTEL_METRIC_EXPORT_INTERVAL={OTEL_METRIC_EXPORT_INTERVAL}")
-logger.info(f"REDIS_URL={'(set)' if REDIS_URL else '(unset, using in-memory store)'}")
+logger.info(f"IRI_IDEMPOTENCY_STORE={IRI_IDEMPOTENCY_STORE if IRI_IDEMPOTENCY_STORE else '(unset, using in-memory store)'}")
 logger.info(f"IDEMPOTENCY_TTL_SECONDS={IDEMPOTENCY_TTL_SECONDS}")
 logger.info(f"LOCK_TTL_SECONDS={LOCK_TTL_SECONDS}")
 logger.info("="*40)

--- a/app/demo_adapter.py
+++ b/app/demo_adapter.py
@@ -6,17 +6,21 @@ import base64
 import datetime
 import glob
 import grp
+import json
 import os
 import pathlib
 import pwd
 import random
 import stat
 import subprocess
+import time
 import uuid
 
+import redis.asyncio as aioredis
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
+from redis.exceptions import WatchError
 
 from .routers.account import facility_adapter as account_adapter
 from .routers.account import models as account_models
@@ -38,6 +42,7 @@ from .types.user import User
 from .types.scalars import AllocationUnit
 from .apilogger import get_stream_logger
 from .config import LOG_LEVEL
+from .idempotency import IdempotencyStore
 
 logger = get_stream_logger(__name__, LOG_LEVEL)
 
@@ -51,6 +56,154 @@ def paginate_list(items, offset: int | None, limit: int | None):
     if limit is not None and limit >= 0:
         items = items[:limit]
     return items
+
+
+_LOCK_PREFIX = "LOCKED:"
+_DONE_PREFIX = "DONE:"
+_LOCK_TTL_SECONDS = int(os.environ.get("LOCK_TTL_SECONDS", 60))
+
+
+class InMemoryIdempotencyStore(IdempotencyStore):
+    """In-process dict store. NOT FOR PROD USE. Enable with:
+      IRI_IDEMPOTENCY_STORE=app.demo_adapter.InMemoryIdempotencyStore
+    """
+
+    def __init__(self, ttl: int | None = None):
+        self._ttl = ttl if ttl is not None else int(os.environ.get("IDEMPOTENCY_TTL_SECONDS", "86400"))
+        self._data: dict[str, tuple[str, float]] = {}
+
+    def _get(self, key: str) -> str | None:
+        entry = self._data.get(key)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if time.monotonic() > expires_at:
+            del self._data[key]
+            return None
+        return value
+
+    def _set(self, key: str, value: str, ttl: int) -> None:
+        self._data[key] = (value, time.monotonic() + ttl)
+
+    def _delete(self, key: str) -> None:
+        self._data.pop(key, None)
+
+    async def check_and_lock(self, cache_key: str, body_hash: str) -> tuple[str, dict | None, int | None]:
+        value = self._get(cache_key)
+
+        if value is None:
+            self._set(cache_key, f"{_LOCK_PREFIX}{body_hash}", _LOCK_TTL_SECONDS)
+            return ("proceed", None, None)
+
+        if value.startswith(_LOCK_PREFIX):
+            return ("conflict", None, None)
+
+        if value.startswith(_DONE_PREFIX):
+            data = json.loads(value[len(_DONE_PREFIX):])
+            if data["body_hash"] != body_hash:
+                return ("fingerprint_mismatch", None, None)
+            return ("hit", data["response_body"], data["response_status"])
+
+        return ("conflict", None, None)
+
+    async def store_result(self, cache_key: str, body_hash: str, response_body: dict, response_status: int) -> None:
+        value = self._get(cache_key)
+        if value != f"{_LOCK_PREFIX}{body_hash}":
+            return
+        data = {"body_hash": body_hash, "response_body": response_body, "response_status": response_status}
+        self._set(cache_key, f"{_DONE_PREFIX}{json.dumps(data)}", self._ttl)
+
+    async def release_lock(self, cache_key: str) -> None:
+        value = self._get(cache_key)
+        if value and value.startswith(_LOCK_PREFIX):
+            self._delete(cache_key)
+
+    async def close(self) -> None:
+        pass
+
+
+class RedisIdempotencyStore(IdempotencyStore):
+    """Redis-backed store. Enable with:
+      IRI_IDEMPOTENCY_STORE=app.demo_adapter.RedisIdempotencyStore
+    Requires: REDIS installed, REDIS_URL env var
+    """
+
+    def __init__(self, redis_url: str | None = None, ttl: int | None = None):
+        _url = redis_url if redis_url is not None else os.environ.get("REDIS_URL", "")
+        if not _url:
+            raise ValueError("REDIS_URL must be set to use RedisIdempotencyStore")
+        self._client = aioredis.from_url(_url, decode_responses=True)
+        self._ttl = ttl if ttl is not None else int(os.environ.get("IDEMPOTENCY_TTL_SECONDS", "86400"))
+
+    def _rkey(self, cache_key: str) -> str:
+        return f"iri:idem:{cache_key}"
+
+    async def check_and_lock(self, cache_key: str, body_hash: str) -> tuple[str, dict | None, int | None]:
+        rkey = self._rkey(cache_key)
+        lock_value = f"{_LOCK_PREFIX}{body_hash}"
+
+        is_new = await self._client.set(rkey, lock_value, nx=True, ex=_LOCK_TTL_SECONDS)
+        if is_new:
+            return ("proceed", None, None)
+
+        value = await self._client.get(rkey)
+        if value is None:
+            # Key expired between our SET NX and GET; try once more.
+            is_new2 = await self._client.set(rkey, lock_value, nx=True, ex=_LOCK_TTL_SECONDS)
+            if is_new2:
+                return ("proceed", None, None)
+            return ("conflict", None, None)
+
+        if value.startswith(_LOCK_PREFIX):
+            return ("conflict", None, None)
+
+        if value.startswith(_DONE_PREFIX):
+            data = json.loads(value[len(_DONE_PREFIX):])
+            if data["body_hash"] != body_hash:
+                return ("fingerprint_mismatch", None, None)
+            return ("hit", data["response_body"], data["response_status"])
+
+        return ("conflict", None, None)
+
+    async def store_result(self, cache_key: str, body_hash: str, response_body: dict, response_status: int) -> None:
+        """Write DONE only if we still own the lock, using WATCH/MULTI/EXEC optimistic locking."""
+        rkey = self._rkey(cache_key)
+        expected_lock = f"{_LOCK_PREFIX}{body_hash}"
+        data = {"body_hash": body_hash, "response_body": response_body, "response_status": response_status}
+        done_value = f"{_DONE_PREFIX}{json.dumps(data)}"
+
+        async with self._client.pipeline() as pipe:
+            try:
+                await pipe.watch(rkey)
+                if await pipe.get(rkey) != expected_lock:
+                    await pipe.reset()
+                    return
+                pipe.multi()
+                pipe.set(rkey, done_value, ex=self._ttl)
+                await pipe.execute()
+            except WatchError:
+                pass  # key changed between watch and execute; another request owns it now
+
+    async def release_lock(self, cache_key: str) -> None:
+        """Delete the lock only if it still holds a LOCKED: value, using WATCH/MULTI/EXEC."""
+        rkey = self._rkey(cache_key)
+
+        async with self._client.pipeline() as pipe:
+            try:
+                await pipe.watch(rkey)
+                current = await pipe.get(rkey)
+                if not (current and current.startswith(_LOCK_PREFIX)):
+                    await pipe.reset()
+                    return
+                pipe.multi()
+                pipe.delete(rkey)
+                await pipe.execute()
+            except WatchError:
+                pass  # key changed between watch and execute; leave it alone
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
 
 class CommandError(RuntimeError):
     """Raised when an external subprocess command fails."""

--- a/app/demo_adapter.py
+++ b/app/demo_adapter.py
@@ -42,7 +42,7 @@ from .types.user import User
 from .types.scalars import AllocationUnit
 from .apilogger import get_stream_logger
 from .config import LOG_LEVEL
-from .idempotency import IdempotencyStore
+from .idempotency import IdempotencyStore, LockState
 
 logger = get_stream_logger(__name__, LOG_LEVEL)
 
@@ -58,8 +58,6 @@ def paginate_list(items, offset: int | None, limit: int | None):
     return items
 
 
-_LOCK_PREFIX = "LOCKED:"
-_DONE_PREFIX = "DONE:"
 _LOCK_TTL_SECONDS = int(os.environ.get("LOCK_TTL_SECONDS", 60))
 
 
@@ -70,9 +68,9 @@ class InMemoryIdempotencyStore(IdempotencyStore):
 
     def __init__(self, ttl: int | None = None):
         self._ttl = ttl if ttl is not None else int(os.environ.get("IDEMPOTENCY_TTL_SECONDS", "86400"))
-        self._data: dict[str, tuple[str, float]] = {}
+        self._data: dict[str, tuple[dict, float]] = {}
 
-    def _get(self, key: str) -> str | None:
+    def _get(self, key: str) -> dict | None:
         entry = self._data.get(key)
         if entry is None:
             return None
@@ -82,24 +80,23 @@ class InMemoryIdempotencyStore(IdempotencyStore):
             return None
         return value
 
-    def _set(self, key: str, value: str, ttl: int) -> None:
+    def _set(self, key: str, value: dict, ttl: int) -> None:
         self._data[key] = (value, time.monotonic() + ttl)
 
     def _delete(self, key: str) -> None:
         self._data.pop(key, None)
 
     async def check_and_lock(self, cache_key: str, body_hash: str) -> tuple[str, dict | None, int | None]:
-        value = self._get(cache_key)
+        data = self._get(cache_key)
 
-        if value is None:
-            self._set(cache_key, f"{_LOCK_PREFIX}{body_hash}", _LOCK_TTL_SECONDS)
+        if data is None:
+            self._set(cache_key, {"state": LockState.LOCKED, "body_hash": body_hash}, _LOCK_TTL_SECONDS)
             return ("proceed", None, None)
 
-        if value.startswith(_LOCK_PREFIX):
+        if data["state"] == LockState.LOCKED:
             return ("conflict", None, None)
 
-        if value.startswith(_DONE_PREFIX):
-            data = json.loads(value[len(_DONE_PREFIX):])
+        if data["state"] == LockState.DONE:
             if data["body_hash"] != body_hash:
                 return ("fingerprint_mismatch", None, None)
             return ("hit", data["response_body"], data["response_status"])
@@ -107,15 +104,14 @@ class InMemoryIdempotencyStore(IdempotencyStore):
         return ("conflict", None, None)
 
     async def store_result(self, cache_key: str, body_hash: str, response_body: dict, response_status: int) -> None:
-        value = self._get(cache_key)
-        if value != f"{_LOCK_PREFIX}{body_hash}":
+        data = self._get(cache_key)
+        if data is None or data.get("state") != LockState.LOCKED or data.get("body_hash") != body_hash:
             return
-        data = {"body_hash": body_hash, "response_body": response_body, "response_status": response_status}
-        self._set(cache_key, f"{_DONE_PREFIX}{json.dumps(data)}", self._ttl)
+        self._set(cache_key, {"state": LockState.DONE, "body_hash": body_hash, "response_body": response_body, "response_status": response_status}, self._ttl)
 
-    async def release_lock(self, cache_key: str) -> None:
-        value = self._get(cache_key)
-        if value and value.startswith(_LOCK_PREFIX):
+    async def delete_lock(self, cache_key: str) -> None:
+        data = self._get(cache_key)
+        if data is not None and data.get("state") == LockState.LOCKED:
             self._delete(cache_key)
 
     async def close(self) -> None:
@@ -140,25 +136,25 @@ class RedisIdempotencyStore(IdempotencyStore):
 
     async def check_and_lock(self, cache_key: str, body_hash: str) -> tuple[str, dict | None, int | None]:
         rkey = self._rkey(cache_key)
-        lock_value = f"{_LOCK_PREFIX}{body_hash}"
+        lock_value = json.dumps({"state": LockState.LOCKED, "body_hash": body_hash})
 
         is_new = await self._client.set(rkey, lock_value, nx=True, ex=_LOCK_TTL_SECONDS)
         if is_new:
             return ("proceed", None, None)
 
-        value = await self._client.get(rkey)
-        if value is None:
+        raw = await self._client.get(rkey)
+        if raw is None:
             # Key expired between our SET NX and GET; try once more.
             is_new2 = await self._client.set(rkey, lock_value, nx=True, ex=_LOCK_TTL_SECONDS)
             if is_new2:
                 return ("proceed", None, None)
             return ("conflict", None, None)
 
-        if value.startswith(_LOCK_PREFIX):
+        data = json.loads(raw)
+        if data["state"] == LockState.LOCKED:
             return ("conflict", None, None)
 
-        if value.startswith(_DONE_PREFIX):
-            data = json.loads(value[len(_DONE_PREFIX):])
+        if data["state"] == LockState.DONE:
             if data["body_hash"] != body_hash:
                 return ("fingerprint_mismatch", None, None)
             return ("hit", data["response_body"], data["response_status"])
@@ -168,9 +164,8 @@ class RedisIdempotencyStore(IdempotencyStore):
     async def store_result(self, cache_key: str, body_hash: str, response_body: dict, response_status: int) -> None:
         """Write DONE only if we still own the lock, using WATCH/MULTI/EXEC optimistic locking."""
         rkey = self._rkey(cache_key)
-        expected_lock = f"{_LOCK_PREFIX}{body_hash}"
-        data = {"body_hash": body_hash, "response_body": response_body, "response_status": response_status}
-        done_value = f"{_DONE_PREFIX}{json.dumps(data)}"
+        expected_lock = json.dumps({"state": LockState.LOCKED, "body_hash": body_hash})
+        done_value = json.dumps({"state": LockState.DONE, "body_hash": body_hash, "response_body": response_body, "response_status": response_status})
 
         async with self._client.pipeline() as pipe:
             try:
@@ -184,15 +179,19 @@ class RedisIdempotencyStore(IdempotencyStore):
             except WatchError:
                 pass  # key changed between watch and execute; another request owns it now
 
-    async def release_lock(self, cache_key: str) -> None:
-        """Delete the lock only if it still holds a LOCKED: value, using WATCH/MULTI/EXEC."""
+    async def delete_lock(self, cache_key: str) -> None:
+        """Delete the lock entry only if still in LOCKED state, using WATCH/MULTI/EXEC."""
         rkey = self._rkey(cache_key)
 
         async with self._client.pipeline() as pipe:
             try:
                 await pipe.watch(rkey)
                 current = await pipe.get(rkey)
-                if not (current and current.startswith(_LOCK_PREFIX)):
+                if not current:
+                    await pipe.reset()
+                    return
+                data = json.loads(current)
+                if data.get("state") != LockState.LOCKED:
                     await pipe.reset()
                     return
                 pipe.multi()

--- a/app/idempotency.py
+++ b/app/idempotency.py
@@ -12,22 +12,25 @@ Backing stores:
   - InMemoryIdempotencyStore  : in-process dict; dev/single-instance only.
   - RedisIdempotencyStore     : Redis-backed; required for multi-replica.
 
-Select via REDIS_URL env var (see config.py).  Install redis extras when using
-Redis: pip install -e ".[redis]"
+Select via REDIS_URL env var (see config.py).
 """
-import os
+
 import hashlib
 import json
 import logging
+import os
 import time
 
 import redis.asyncio as aioredis
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+from redis.exceptions import WatchError
 
 log = logging.getLogger(__name__)
 
 _LOCK_PREFIX = "LOCKED:"
 _DONE_PREFIX = "DONE:"
-_LOCK_TTL_SECONDS = int(os.environ.get("LOCK_TTL_SECONDS", 60))  # max seconds a handler may hold the lock before it is considered dead
+_LOCK_TTL_SECONDS = int(os.environ.get("LOCK_TTL_SECONDS", 60))
 
 
 def build_cache_key(user_id: str, idempotency_key: str, endpoint: str) -> str:
@@ -40,6 +43,27 @@ def build_body_hash(body: dict | None) -> str:
     """Stable hash of the request body used to detect fingerprint mismatches."""
     raw = json.dumps(body, sort_keys=True, default=str)
     return hashlib.sha256(raw.encode()).hexdigest()
+
+
+async def run_with_idempotency(store, cache_key: str, body_hash: str, adapter_fn) -> JSONResponse:
+    """Run adapter_fn under idempotency control."""
+    action, cached_body, cached_status = await store.check_and_lock(cache_key, body_hash)
+
+    if action == "hit":
+        return JSONResponse(content=cached_body, status_code=cached_status or 200, headers={"Idempotency-Key-Reply": "hit"})
+    if action == "conflict":
+        raise HTTPException(status_code=409, detail="A request with this Idempotency-Key is already in progress.", headers={"Retry-After": "2"})
+    if action == "fingerprint_mismatch":
+        raise HTTPException(status_code=422, detail="Idempotency-Key reused with a different request body.")
+
+    try:
+        result = await adapter_fn()
+        body = result.model_dump(exclude_unset=True)
+        await store.store_result(cache_key, body_hash, body, 200)
+        return JSONResponse(content=body, status_code=200, headers={"Idempotency-Key-Reply": "miss"})
+    except Exception:
+        await store.release_lock(cache_key)
+        raise
 
 
 class InMemoryIdempotencyStore:
@@ -68,9 +92,9 @@ class InMemoryIdempotencyStore:
     async def check_and_lock(self, cache_key: str, body_hash: str) -> tuple[str, dict | None, int | None]:
         """Check state and acquire lock for a new request.
         Possible returns:
-          ("proceed", None, None)            -- new request; caller must call store_result or release_lock
-          ("hit", body_dict, status_int)     -- cached result; return it directly
-          ("conflict", None, None)           -- in-flight; caller should return 409
+          ("proceed", None, None)              -- new request; caller must call store_result or release_lock
+          ("hit", body_dict, status_int)       -- cached result; return it directly
+          ("conflict", None, None)             -- in-flight; caller should return 409
           ("fingerprint_mismatch", None, None) -- same key, different body; caller should return 422
         """
         value = self._get(cache_key)
@@ -91,12 +115,21 @@ class InMemoryIdempotencyStore:
         return ("conflict", None, None)
 
     async def store_result(self, cache_key: str, body_hash: str, response_body: dict, response_status: int) -> None:
-        """Overwrite the lock entry with the final response and extend TTL"""
+        """Overwrite the lock entry with the final response and extend TTL.
+
+        Single-threaded asyncio: no await between the check and set, so this is atomic.
+        """
+        value = self._get(cache_key)
+        if value != f"{_LOCK_PREFIX}{body_hash}":
+            return
         data = {"body_hash": body_hash, "response_body": response_body, "response_status": response_status}
         self._set(cache_key, f"{_DONE_PREFIX}{json.dumps(data)}", self._ttl)
 
     async def release_lock(self, cache_key: str) -> None:
-        """Delete the lock"""
+        """Delete the lock.
+
+        Single-threaded asyncio: no await between the check and delete, so this is atomic.
+        """
         value = self._get(cache_key)
         if value and value.startswith(_LOCK_PREFIX):
             self._delete(cache_key)
@@ -125,6 +158,7 @@ class RedisIdempotencyStore:
 
         value = await self._client.get(rkey)
         if value is None:
+            # Key expired between our SET NX and GET; try once more.
             is_new2 = await self._client.set(rkey, lock_value, nx=True, ex=_LOCK_TTL_SECONDS)
             if is_new2:
                 return ("proceed", None, None)
@@ -142,14 +176,47 @@ class RedisIdempotencyStore:
         return ("conflict", None, None)
 
     async def store_result(self, cache_key: str, body_hash: str, response_body: dict, response_status: int) -> None:
+        """Write DONE only if we still own the lock, using WATCH/MULTI/EXEC optimistic locking.
+
+        If the lock expired and another request acquired it between check_and_lock and here,
+        the WATCH detects the change and the SET is skipped.
+        """
+        rkey = self._rkey(cache_key)
+        expected_lock = f"{_LOCK_PREFIX}{body_hash}"
         data = {"body_hash": body_hash, "response_body": response_body, "response_status": response_status}
-        await self._client.set(self._rkey(cache_key), f"{_DONE_PREFIX}{json.dumps(data)}", ex=self._ttl)
+        done_value = f"{_DONE_PREFIX}{json.dumps(data)}"
+
+        async with self._client.pipeline() as pipe:
+            try:
+                await pipe.watch(rkey)
+                if await pipe.get(rkey) != expected_lock:
+                    await pipe.reset()
+                    return
+                pipe.multi()
+                pipe.set(rkey, done_value, ex=self._ttl)
+                await pipe.execute()
+            except WatchError:
+                pass  # key changed between watch and execute; another request owns it now
 
     async def release_lock(self, cache_key: str) -> None:
+        """Delete the lock only if it still holds a LOCKED: value, using WATCH/MULTI/EXEC.
+
+        Prevents deleting a lock that expired and was re-acquired by a different request.
+        """
         rkey = self._rkey(cache_key)
-        value = await self._client.get(rkey)
-        if value and value.startswith(_LOCK_PREFIX):
-            await self._client.delete(rkey)
+
+        async with self._client.pipeline() as pipe:
+            try:
+                await pipe.watch(rkey)
+                current = await pipe.get(rkey)
+                if not (current and current.startswith(_LOCK_PREFIX)):
+                    await pipe.reset()
+                    return
+                pipe.multi()
+                pipe.delete(rkey)
+                await pipe.execute()
+            except WatchError:
+                pass  # key changed between watch and execute; leave it alone
 
     async def close(self) -> None:
         await self._client.aclose()

--- a/app/idempotency.py
+++ b/app/idempotency.py
@@ -87,7 +87,8 @@ async def run_with_idempotency(store: IdempotencyStore, cache_key: str, body_has
         body = result.model_dump(exclude_unset=True)
         await store.store_result(cache_key, body_hash, body, 200)
         return JSONResponse(content=body, status_code=200, headers={"Idempotency-Key-Reply": "miss"})
-    except Exception:
+    except Exception as exc:
+        log.error("Adapter raised during idempotent call; releasing lock for key %s: %s", cache_key, exc)
         await store.release_lock(cache_key)
         raise
 

--- a/app/idempotency.py
+++ b/app/idempotency.py
@@ -20,11 +20,17 @@ import json
 import logging
 import os
 from abc import ABC, abstractmethod
+from enum import Enum
 
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 
 log = logging.getLogger(__name__)
+
+
+class LockState(str, Enum):
+    LOCKED = "LOCKED"
+    DONE = "DONE"
 
 
 def build_cache_key(user_id: str, idempotency_key: str, endpoint: str) -> str:
@@ -61,9 +67,9 @@ class IdempotencyStore(ABC):
         """
 
     @abstractmethod
-    async def release_lock(self, cache_key: str) -> None:
-        """Release the lock when the adapter raises an exception.
-        Must be owner-checked: no-op if the key no longer holds a LOCKED: value.
+    async def delete_lock(self, cache_key: str) -> None:
+        """Delete the lock entry when the adapter raises an exception.
+        Must be owner-checked: no-op if the key is no longer in LOCKED state.
         """
 
     @abstractmethod
@@ -89,7 +95,7 @@ async def run_with_idempotency(store: IdempotencyStore, cache_key: str, body_has
         return JSONResponse(content=body, status_code=200, headers={"Idempotency-Key-Reply": "miss"})
     except Exception as exc:
         log.error("Adapter raised during idempotent call; releasing lock for key %s: %s", cache_key, exc)
-        await store.release_lock(cache_key)
+        await store.delete_lock(cache_key)
         raise
 
 

--- a/app/idempotency.py
+++ b/app/idempotency.py
@@ -1,4 +1,4 @@
-"""Idempotency store for mutating endpoints (submit_job, update_job).
+"""Idempotency store for mutating API endpoints (submit_job, update_job).
 
 Behaviour by Idempotency-Key header:
   - No header         -> pass through, normal execution every time.
@@ -8,29 +8,23 @@ Behaviour by Idempotency-Key header:
   - Same key, different body -> 422 Unprocessable Entity.
   - Adapter raises    -> lock is released; client may retry safely.
 
-Backing stores:
+The backing store is defined via IRI_IDEMPOTENCY_STORE (see create_store).
+Reference implementations:
   - InMemoryIdempotencyStore  : in-process dict; dev/single-instance only.
-  - RedisIdempotencyStore     : Redis-backed; required for multi-replica.
-
-Select via REDIS_URL env var (see config.py).
+  - RedisIdempotencyStore     : Redis-backed;
 """
 
 import hashlib
+import importlib
 import json
 import logging
 import os
-import time
+from abc import ABC, abstractmethod
 
-import redis.asyncio as aioredis
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
-from redis.exceptions import WatchError
 
 log = logging.getLogger(__name__)
-
-_LOCK_PREFIX = "LOCKED:"
-_DONE_PREFIX = "DONE:"
-_LOCK_TTL_SECONDS = int(os.environ.get("LOCK_TTL_SECONDS", 60))
 
 
 def build_cache_key(user_id: str, idempotency_key: str, endpoint: str) -> str:
@@ -45,7 +39,39 @@ def build_body_hash(body: dict | None) -> str:
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
-async def run_with_idempotency(store, cache_key: str, body_hash: str, adapter_fn) -> JSONResponse:
+class IdempotencyStore(ABC):
+    """Abstract class for idempotency backing stores.
+    """
+
+    @abstractmethod
+    async def check_and_lock(self, cache_key: str, body_hash: str) -> tuple[str, dict | None, int | None]:
+        """Check state and acquire lock for a new request.
+
+        Returns one of:
+          ("proceed", None, None)              -- new request; caller must call store_result or release_lock
+          ("hit", body_dict, status_int)       -- cached result; return it directly
+          ("conflict", None, None)             -- in-flight; caller should return 409
+          ("fingerprint_mismatch", None, None) -- same key, different body; caller should return 422
+        """
+
+    @abstractmethod
+    async def store_result(self, cache_key: str, body_hash: str, response_body: dict, response_status: int) -> None:
+        """Persist the final response and transition the key to DONE state.
+        Must be owner-checked: no-op if this caller no longer holds the lock.
+        """
+
+    @abstractmethod
+    async def release_lock(self, cache_key: str) -> None:
+        """Release the lock when the adapter raises an exception.
+        Must be owner-checked: no-op if the key no longer holds a LOCKED: value.
+        """
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Release connections and resources at application shutdown."""
+
+
+async def run_with_idempotency(store: IdempotencyStore, cache_key: str, body_hash: str, adapter_fn) -> JSONResponse:
     """Run adapter_fn under idempotency control."""
     action, cached_body, cached_status = await store.check_and_lock(cache_key, body_hash)
 
@@ -66,167 +92,19 @@ async def run_with_idempotency(store, cache_key: str, body_hash: str, adapter_fn
         raise
 
 
-class InMemoryIdempotencyStore:
-    """Simple in-process dict store with monotonic-clock TTL. Only for DEV"""
+def create_store() -> IdempotencyStore:
+    """Return the idempotency store configured via IRI_IDEMPOTENCY_STORE.
 
-    def __init__(self, ttl: int):
-        self._ttl = ttl
-        self._data: dict[str, tuple[str, float]] = {}
-
-    def _get(self, key: str) -> str | None:
-        entry = self._data.get(key)
-        if entry is None:
-            return None
-        value, expires_at = entry
-        if time.monotonic() > expires_at:
-            del self._data[key]
-            return None
-        return value
-
-    def _set(self, key: str, value: str, ttl: int) -> None:
-        self._data[key] = (value, time.monotonic() + ttl)
-
-    def _delete(self, key: str) -> None:
-        self._data.pop(key, None)
-
-    async def check_and_lock(self, cache_key: str, body_hash: str) -> tuple[str, dict | None, int | None]:
-        """Check state and acquire lock for a new request.
-        Possible returns:
-          ("proceed", None, None)              -- new request; caller must call store_result or release_lock
-          ("hit", body_dict, status_int)       -- cached result; return it directly
-          ("conflict", None, None)             -- in-flight; caller should return 409
-          ("fingerprint_mismatch", None, None) -- same key, different body; caller should return 422
-        """
-        value = self._get(cache_key)
-
-        if value is None:
-            self._set(cache_key, f"{_LOCK_PREFIX}{body_hash}", _LOCK_TTL_SECONDS)
-            return ("proceed", None, None)
-
-        if value.startswith(_LOCK_PREFIX):
-            return ("conflict", None, None)
-
-        if value.startswith(_DONE_PREFIX):
-            data = json.loads(value[len(_DONE_PREFIX):])
-            if data["body_hash"] != body_hash:
-                return ("fingerprint_mismatch", None, None)
-            return ("hit", data["response_body"], data["response_status"])
-
-        return ("conflict", None, None)
-
-    async def store_result(self, cache_key: str, body_hash: str, response_body: dict, response_status: int) -> None:
-        """Overwrite the lock entry with the final response and extend TTL.
-
-        Single-threaded asyncio: no await between the check and set, so this is atomic.
-        """
-        value = self._get(cache_key)
-        if value != f"{_LOCK_PREFIX}{body_hash}":
-            return
-        data = {"body_hash": body_hash, "response_body": response_body, "response_status": response_status}
-        self._set(cache_key, f"{_DONE_PREFIX}{json.dumps(data)}", self._ttl)
-
-    async def release_lock(self, cache_key: str) -> None:
-        """Delete the lock.
-
-        Single-threaded asyncio: no await between the check and delete, so this is atomic.
-        """
-        value = self._get(cache_key)
-        if value and value.startswith(_LOCK_PREFIX):
-            self._delete(cache_key)
-
-    async def close(self) -> None:
-        pass
-
-
-class RedisIdempotencyStore:
-    """Redis-backed Idempotency Store"""
-
-    def __init__(self, redis_url: str, ttl: int):
-        self._client = aioredis.from_url(redis_url, decode_responses=True)
-        self._ttl = ttl
-
-    def _rkey(self, cache_key: str) -> str:
-        return f"iri:idem:{cache_key}"
-
-    async def check_and_lock(self, cache_key: str, body_hash: str) -> tuple[str, dict | None, int | None]:
-        rkey = self._rkey(cache_key)
-        lock_value = f"{_LOCK_PREFIX}{body_hash}"
-
-        is_new = await self._client.set(rkey, lock_value, nx=True, ex=_LOCK_TTL_SECONDS)
-        if is_new:
-            return ("proceed", None, None)
-
-        value = await self._client.get(rkey)
-        if value is None:
-            # Key expired between our SET NX and GET; try once more.
-            is_new2 = await self._client.set(rkey, lock_value, nx=True, ex=_LOCK_TTL_SECONDS)
-            if is_new2:
-                return ("proceed", None, None)
-            return ("conflict", None, None)
-
-        if value.startswith(_LOCK_PREFIX):
-            return ("conflict", None, None)
-
-        if value.startswith(_DONE_PREFIX):
-            data = json.loads(value[len(_DONE_PREFIX):])
-            if data["body_hash"] != body_hash:
-                return ("fingerprint_mismatch", None, None)
-            return ("hit", data["response_body"], data["response_status"])
-
-        return ("conflict", None, None)
-
-    async def store_result(self, cache_key: str, body_hash: str, response_body: dict, response_status: int) -> None:
-        """Write DONE only if we still own the lock, using WATCH/MULTI/EXEC optimistic locking.
-
-        If the lock expired and another request acquired it between check_and_lock and here,
-        the WATCH detects the change and the SET is skipped.
-        """
-        rkey = self._rkey(cache_key)
-        expected_lock = f"{_LOCK_PREFIX}{body_hash}"
-        data = {"body_hash": body_hash, "response_body": response_body, "response_status": response_status}
-        done_value = f"{_DONE_PREFIX}{json.dumps(data)}"
-
-        async with self._client.pipeline() as pipe:
-            try:
-                await pipe.watch(rkey)
-                if await pipe.get(rkey) != expected_lock:
-                    await pipe.reset()
-                    return
-                pipe.multi()
-                pipe.set(rkey, done_value, ex=self._ttl)
-                await pipe.execute()
-            except WatchError:
-                pass  # key changed between watch and execute; another request owns it now
-
-    async def release_lock(self, cache_key: str) -> None:
-        """Delete the lock only if it still holds a LOCKED: value, using WATCH/MULTI/EXEC.
-
-        Prevents deleting a lock that expired and was re-acquired by a different request.
-        """
-        rkey = self._rkey(cache_key)
-
-        async with self._client.pipeline() as pipe:
-            try:
-                await pipe.watch(rkey)
-                current = await pipe.get(rkey)
-                if not (current and current.startswith(_LOCK_PREFIX)):
-                    await pipe.reset()
-                    return
-                pipe.multi()
-                pipe.delete(rkey)
-                await pipe.execute()
-            except WatchError:
-                pass  # key changed between watch and execute; leave it alone
-
-    async def close(self) -> None:
-        await self._client.aclose()
-
-
-def create_store(redis_url: str, ttl: int) -> InMemoryIdempotencyStore | RedisIdempotencyStore:
-    """Return Redis-backed store if REDIS_URL is set, in-memory otherwise."""
-    if redis_url:
-        store = RedisIdempotencyStore(redis_url, ttl)
-        log.info("Idempotency store: Redis at %s (TTL %ds)", redis_url, ttl)
-        return store
-    log.info("Idempotency store: in-memory (single-instance; TTL %ds)", ttl)
-    return InMemoryIdempotencyStore(ttl)
+    The named class is imported and instantiated with no arguments — it reads any
+    connection strings or config it needs from env vars.
+    Defaults to app.demo_adapter.InMemoryIdempotencyStore (single-instance; not for production).
+    """
+    class_path = os.environ.get("IRI_IDEMPOTENCY_STORE", "app.demo_adapter.InMemoryIdempotencyStore")
+    parts = class_path.rsplit(".", 1)
+    module = importlib.import_module(parts[0])
+    StoreClass = getattr(module, parts[1])
+    if not issubclass(StoreClass, IdempotencyStore):
+        raise ValueError(f"{class_path} must subclass IdempotencyStore")
+    store = StoreClass()
+    log.info("Idempotency store: %s", class_path)
+    return store

--- a/app/idempotency.py
+++ b/app/idempotency.py
@@ -1,0 +1,165 @@
+"""Idempotency store for mutating endpoints (submit_job, update_job).
+
+Behaviour by Idempotency-Key header:
+  - No header         -> pass through, normal execution every time.
+  - First request     -> lock key, run handler, cache 200 response, return it.
+  - Retry same key    -> return cached response without calling the adapter again.
+  - In-flight same key -> 409 Conflict (Retry-After: 2).
+  - Same key, different body -> 422 Unprocessable Entity.
+  - Adapter raises    -> lock is released; client may retry safely.
+
+Backing stores:
+  - InMemoryIdempotencyStore  : in-process dict; dev/single-instance only.
+  - RedisIdempotencyStore     : Redis-backed; required for multi-replica.
+
+Select via REDIS_URL env var (see config.py).  Install redis extras when using
+Redis: pip install -e ".[redis]"
+"""
+import os
+import hashlib
+import json
+import logging
+import time
+
+import redis.asyncio as aioredis
+
+log = logging.getLogger(__name__)
+
+_LOCK_PREFIX = "LOCKED:"
+_DONE_PREFIX = "DONE:"
+_LOCK_TTL_SECONDS = int(os.environ.get("LOCK_TTL_SECONDS", 60))  # max seconds a handler may hold the lock before it is considered dead
+
+
+def build_cache_key(user_id: str, idempotency_key: str, endpoint: str) -> str:
+    """Produce a scoped, opaque cache key from user + key + endpoint."""
+    raw = f"{user_id}:{endpoint}:{idempotency_key}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def build_body_hash(body: dict | None) -> str:
+    """Stable hash of the request body used to detect fingerprint mismatches."""
+    raw = json.dumps(body, sort_keys=True, default=str)
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+class InMemoryIdempotencyStore:
+    """Simple in-process dict store with monotonic-clock TTL. Only for DEV"""
+
+    def __init__(self, ttl: int):
+        self._ttl = ttl
+        self._data: dict[str, tuple[str, float]] = {}
+
+    def _get(self, key: str) -> str | None:
+        entry = self._data.get(key)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if time.monotonic() > expires_at:
+            del self._data[key]
+            return None
+        return value
+
+    def _set(self, key: str, value: str, ttl: int) -> None:
+        self._data[key] = (value, time.monotonic() + ttl)
+
+    def _delete(self, key: str) -> None:
+        self._data.pop(key, None)
+
+    async def check_and_lock(self, cache_key: str, body_hash: str) -> tuple[str, dict | None, int | None]:
+        """Check state and acquire lock for a new request.
+        Possible returns:
+          ("proceed", None, None)            -- new request; caller must call store_result or release_lock
+          ("hit", body_dict, status_int)     -- cached result; return it directly
+          ("conflict", None, None)           -- in-flight; caller should return 409
+          ("fingerprint_mismatch", None, None) -- same key, different body; caller should return 422
+        """
+        value = self._get(cache_key)
+
+        if value is None:
+            self._set(cache_key, f"{_LOCK_PREFIX}{body_hash}", _LOCK_TTL_SECONDS)
+            return ("proceed", None, None)
+
+        if value.startswith(_LOCK_PREFIX):
+            return ("conflict", None, None)
+
+        if value.startswith(_DONE_PREFIX):
+            data = json.loads(value[len(_DONE_PREFIX):])
+            if data["body_hash"] != body_hash:
+                return ("fingerprint_mismatch", None, None)
+            return ("hit", data["response_body"], data["response_status"])
+
+        return ("conflict", None, None)
+
+    async def store_result(self, cache_key: str, body_hash: str, response_body: dict, response_status: int) -> None:
+        """Overwrite the lock entry with the final response and extend TTL"""
+        data = {"body_hash": body_hash, "response_body": response_body, "response_status": response_status}
+        self._set(cache_key, f"{_DONE_PREFIX}{json.dumps(data)}", self._ttl)
+
+    async def release_lock(self, cache_key: str) -> None:
+        """Delete the lock"""
+        value = self._get(cache_key)
+        if value and value.startswith(_LOCK_PREFIX):
+            self._delete(cache_key)
+
+    async def close(self) -> None:
+        pass
+
+
+class RedisIdempotencyStore:
+    """Redis-backed Idempotency Store"""
+
+    def __init__(self, redis_url: str, ttl: int):
+        self._client = aioredis.from_url(redis_url, decode_responses=True)
+        self._ttl = ttl
+
+    def _rkey(self, cache_key: str) -> str:
+        return f"iri:idem:{cache_key}"
+
+    async def check_and_lock(self, cache_key: str, body_hash: str) -> tuple[str, dict | None, int | None]:
+        rkey = self._rkey(cache_key)
+        lock_value = f"{_LOCK_PREFIX}{body_hash}"
+
+        is_new = await self._client.set(rkey, lock_value, nx=True, ex=_LOCK_TTL_SECONDS)
+        if is_new:
+            return ("proceed", None, None)
+
+        value = await self._client.get(rkey)
+        if value is None:
+            is_new2 = await self._client.set(rkey, lock_value, nx=True, ex=_LOCK_TTL_SECONDS)
+            if is_new2:
+                return ("proceed", None, None)
+            return ("conflict", None, None)
+
+        if value.startswith(_LOCK_PREFIX):
+            return ("conflict", None, None)
+
+        if value.startswith(_DONE_PREFIX):
+            data = json.loads(value[len(_DONE_PREFIX):])
+            if data["body_hash"] != body_hash:
+                return ("fingerprint_mismatch", None, None)
+            return ("hit", data["response_body"], data["response_status"])
+
+        return ("conflict", None, None)
+
+    async def store_result(self, cache_key: str, body_hash: str, response_body: dict, response_status: int) -> None:
+        data = {"body_hash": body_hash, "response_body": response_body, "response_status": response_status}
+        await self._client.set(self._rkey(cache_key), f"{_DONE_PREFIX}{json.dumps(data)}", ex=self._ttl)
+
+    async def release_lock(self, cache_key: str) -> None:
+        rkey = self._rkey(cache_key)
+        value = await self._client.get(rkey)
+        if value and value.startswith(_LOCK_PREFIX):
+            await self._client.delete(rkey)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+
+def create_store(redis_url: str, ttl: int) -> InMemoryIdempotencyStore | RedisIdempotencyStore:
+    """Return Redis-backed store if REDIS_URL is set, in-memory otherwise."""
+    if redis_url:
+        store = RedisIdempotencyStore(redis_url, ttl)
+        log.info("Idempotency store: Redis at %s (TTL %ds)", redis_url, ttl)
+        return store
+    log.info("Idempotency store: in-memory (single-instance; TTL %ds)", ttl)
+    return InMemoryIdempotencyStore(ttl)

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,8 @@
 """Main API application"""
 
 import logging
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from opentelemetry import trace, metrics
@@ -17,6 +19,7 @@ from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
 from . import config
 from .apilogger import configure_logging
+from .idempotency import create_store
 from .request_context import _api_url_base, _iri_facility_project, set_api_url_base
 
 from app.routers.error_handlers import install_error_handlers
@@ -54,7 +57,14 @@ if config.OPENTELEMETRY_ENABLED:
         metrics.set_meter_provider(MeterProvider(resource=resource, metric_readers=[metric_reader]))
 # ------------------------------------------------------------------
 
-APP = FastAPI(servers=[{"url": config.API_URL_ROOT}], **config.API_CONFIG)
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    app.state.idempotency_store = create_store(config.REDIS_URL, config.IDEMPOTENCY_TTL_SECONDS)
+    yield
+    await app.state.idempotency_store.close()
+
+
+APP = FastAPI(servers=[{"url": config.API_URL_ROOT}], lifespan=_lifespan, **config.API_CONFIG)
 
 
 class _ExternalRequestContextMiddleware(BaseHTTPMiddleware):

--- a/app/main.py
+++ b/app/main.py
@@ -59,7 +59,7 @@ if config.OPENTELEMETRY_ENABLED:
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
-    app.state.idempotency_store = create_store(config.REDIS_URL, config.IDEMPOTENCY_TTL_SECONDS)
+    app.state.idempotency_store = create_store()
     yield
     await app.state.idempotency_store.close()
 

--- a/app/routers/compute/compute.py
+++ b/app/routers/compute/compute.py
@@ -1,7 +1,9 @@
 """Compute resource API router"""
 
-from fastapi import Depends, Query, Request, status
+from fastapi import Depends, Header, HTTPException, Query, Request, status
+from fastapi.responses import JSONResponse
 
+from ...idempotency import build_body_hash, build_cache_key
 from ...types.http import forbidExtraQueryParams
 from ...types.scalars import StrictHTTPBool
 from ...types.user import User
@@ -49,6 +51,7 @@ async def submit_job(
     user: User = Depends(router.current_user),
     project_name: str | None = Depends(router.iri_header_project),
     _forbid=Depends(forbidExtraQueryParams()),
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
 ):
     """
     Submit a job on a compute resource
@@ -61,14 +64,38 @@ async def submit_job(
       If the forwarded header is present and valid, IRI treats its value as the effective facility-native project/account
       for the downstream submission and related job metadata. If both sources are present, or neither is present,
       the request is rejected with `400 Bad Request`.
+    - **Idempotency-Key**: optional client-generated UUID. A retry with the same key and body
+      returns the original response without re-submitting the job. Same key with a different body
+      returns 422. An in-flight duplicate returns 409.
 
     This command will attempt to submit a job and return its id.
     """
-    # look up the resource (todo: maybe ensure it's available)
     resource = await status_router.adapter.get_resource(resource_id)
 
-    # the handler can use whatever means it wants to submit the job and then fill in its id
-    # see: https://exaworks.org/psij-python/docs/v/0.9.11/user_guide.html#submitting-jobs
+    if idempotency_key:
+        store = request.app.state.idempotency_store
+        cache_key = build_cache_key(user.id, idempotency_key, "submit_job")
+        body_hash = build_body_hash(job_spec.model_dump())
+
+        action, cached_body, cached_status = await store.check_and_lock(cache_key, body_hash)
+
+        if action == "hit":
+            return JSONResponse(content=cached_body, status_code=cached_status or 200, headers={"Idempotency-Key-Reply": "hit"})
+        if action == "conflict":
+            raise HTTPException(status_code=409, detail="A request with this Idempotency-Key is already in progress.", headers={"Retry-After": "2"})
+        if action == "fingerprint_mismatch":
+            raise HTTPException(status_code=422, detail="Idempotency-Key reused with a different request body.")
+
+        # action == "proceed": first request; run handler, cache result.
+        try:
+            result = await router.adapter.submit_job(resource=resource, user=user, job_spec=job_spec)
+            body = result.model_dump(exclude_unset=True)
+            await store.store_result(cache_key, body_hash, body, 200)
+            return JSONResponse(content=body, status_code=200, headers={"Idempotency-Key-Reply": "miss"})
+        except Exception:
+            await store.release_lock(cache_key)
+            raise
+
     return await router.adapter.submit_job(resource=resource, user=user, job_spec=job_spec)
 
 
@@ -88,6 +115,7 @@ async def update_job(
     user: User = Depends(router.current_user),
     project_name: str | None = Depends(router.iri_header_project),
     _forbid=Depends(forbidExtraQueryParams()),
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
 ):
     """
     Update a previously submitted job for a resource.
@@ -101,13 +129,34 @@ async def update_job(
       If the forwarded header is present and valid, IRI treats its value as the effective facility-native project/account
       for downstream update handling and job metadata. If both sources are present, or neither is present,
       the request is rejected with `400 Bad Request`.
-
+    - **Idempotency-Key**: optional client-generated UUID. Same semantics as submit_job.
     """
-    # look up the resource (todo: maybe ensure it's available)
     resource = await status_router.adapter.get_resource(resource_id)
 
-    # the handler can use whatever means it wants to submit the job and then fill in its id
-    # see: https://exaworks.org/psij-python/docs/v/0.9.11/user_guide.html#submitting-jobs
+    if idempotency_key:
+        store = request.app.state.idempotency_store
+        # Include job_id in the cache key so different jobs don't collide.
+        cache_key = build_cache_key(user.id, idempotency_key, f"update_job:{job_id}")
+        body_hash = build_body_hash(job_spec.model_dump())
+
+        action, cached_body, cached_status = await store.check_and_lock(cache_key, body_hash)
+
+        if action == "hit":
+            return JSONResponse(content=cached_body, status_code=cached_status or 200, headers={"Idempotency-Key-Reply": "hit"})
+        if action == "conflict":
+            raise HTTPException(status_code=409, detail="A request with this Idempotency-Key is already in progress.", headers={"Retry-After": "2"})
+        if action == "fingerprint_mismatch":
+            raise HTTPException(status_code=422, detail="Idempotency-Key reused with a different request body.")
+
+        try:
+            result = await router.adapter.update_job(resource=resource, user=user, job_spec=job_spec, job_id=job_id)
+            body = result.model_dump(exclude_unset=True)
+            await store.store_result(cache_key, body_hash, body, 200)
+            return JSONResponse(content=body, status_code=200, headers={"Idempotency-Key-Reply": "miss"})
+        except Exception:
+            await store.release_lock(cache_key)
+            raise
+
     return await router.adapter.update_job(resource=resource, user=user, job_spec=job_spec, job_id=job_id)
 
 

--- a/app/routers/compute/compute.py
+++ b/app/routers/compute/compute.py
@@ -1,9 +1,8 @@
 """Compute resource API router"""
 
-from fastapi import Depends, Header, HTTPException, Query, Request, status
-from fastapi.responses import JSONResponse
+from fastapi import Depends, Header, Query, Request, status
 
-from ...idempotency import build_body_hash, build_cache_key
+from ...idempotency import build_body_hash, build_cache_key, run_with_idempotency
 from ...types.http import forbidExtraQueryParams
 from ...types.scalars import StrictHTTPBool
 from ...types.user import User
@@ -73,29 +72,12 @@ async def submit_job(
     resource = await status_router.adapter.get_resource(resource_id)
 
     if idempotency_key:
-        store = request.app.state.idempotency_store
-        cache_key = build_cache_key(user.id, idempotency_key, "submit_job")
-        body_hash = build_body_hash(job_spec.model_dump())
-
-        action, cached_body, cached_status = await store.check_and_lock(cache_key, body_hash)
-
-        if action == "hit":
-            return JSONResponse(content=cached_body, status_code=cached_status or 200, headers={"Idempotency-Key-Reply": "hit"})
-        if action == "conflict":
-            raise HTTPException(status_code=409, detail="A request with this Idempotency-Key is already in progress.", headers={"Retry-After": "2"})
-        if action == "fingerprint_mismatch":
-            raise HTTPException(status_code=422, detail="Idempotency-Key reused with a different request body.")
-
-        # action == "proceed": first request; run handler, cache result.
-        try:
-            result = await router.adapter.submit_job(resource=resource, user=user, job_spec=job_spec)
-            body = result.model_dump(exclude_unset=True)
-            await store.store_result(cache_key, body_hash, body, 200)
-            return JSONResponse(content=body, status_code=200, headers={"Idempotency-Key-Reply": "miss"})
-        except Exception:
-            await store.release_lock(cache_key)
-            raise
-
+        return await run_with_idempotency(
+            request.app.state.idempotency_store,
+            build_cache_key(user.id, idempotency_key, "submit_job"),
+            build_body_hash(job_spec.model_dump()),
+            lambda: router.adapter.submit_job(resource=resource, user=user, job_spec=job_spec),
+        )
     return await router.adapter.submit_job(resource=resource, user=user, job_spec=job_spec)
 
 
@@ -134,29 +116,12 @@ async def update_job(
     resource = await status_router.adapter.get_resource(resource_id)
 
     if idempotency_key:
-        store = request.app.state.idempotency_store
-        # Include job_id in the cache key so different jobs don't collide.
-        cache_key = build_cache_key(user.id, idempotency_key, f"update_job:{job_id}")
-        body_hash = build_body_hash(job_spec.model_dump())
-
-        action, cached_body, cached_status = await store.check_and_lock(cache_key, body_hash)
-
-        if action == "hit":
-            return JSONResponse(content=cached_body, status_code=cached_status or 200, headers={"Idempotency-Key-Reply": "hit"})
-        if action == "conflict":
-            raise HTTPException(status_code=409, detail="A request with this Idempotency-Key is already in progress.", headers={"Retry-After": "2"})
-        if action == "fingerprint_mismatch":
-            raise HTTPException(status_code=422, detail="Idempotency-Key reused with a different request body.")
-
-        try:
-            result = await router.adapter.update_job(resource=resource, user=user, job_spec=job_spec, job_id=job_id)
-            body = result.model_dump(exclude_unset=True)
-            await store.store_result(cache_key, body_hash, body, 200)
-            return JSONResponse(content=body, status_code=200, headers={"Idempotency-Key-Reply": "miss"})
-        except Exception:
-            await store.release_lock(cache_key)
-            raise
-
+        return await run_with_idempotency(
+            request.app.state.idempotency_store,
+            build_cache_key(user.id, idempotency_key, f"update_job:{job_id}"),
+            build_body_hash(job_spec.model_dump()),
+            lambda: router.adapter.update_job(resource=resource, user=user, job_spec=job_spec, job_id=job_id),
+        )
     return await router.adapter.update_job(resource=resource, user=user, job_spec=job_spec, job_id=job_id)
 
 

--- a/local-template.env
+++ b/local-template.env
@@ -1,3 +1,10 @@
+# Idempotency store
+# Uncomment REDIS_URL to enable Redis-backed idempotency (required for multi-replica deployments).
+# Without it, an in-process dict is used (dev / single-instance only).
+#export REDIS_URL=redis://localhost:6379
+#export IDEMPOTENCY_TTL_SECONDS=86400   # how long a successful response is cached (default: 24h)
+#export LOCK_TTL_SECONDS=60             # max in-flight lock lifetime before auto-expiry (default: 60s)
+
 # globus app credentials
 export GLOBUS_APP_ID=<your dev app's id goes here>
 export GLOBUS_APP_SECRET=<your dev app's secret goes here>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ dependencies = [
     "opentelemetry-exporter-otlp>=1.39.1,<1.40.0",
     "globus-sdk>=4.3.1",
     "typer>=0.24.1",
+    "redis>=7.2.0,<8.0.0",
 ]
+
 [tool.ruff]
 line-length = 200
 exclude = [".venv", "__pycache__", "build", "dist"]


### PR DESCRIPTION
This adds an optional Idempotency-Key request [see Ref 1] header for submit/update job.

This is mainly to prevent duplicate job submissions on client retries (retries, lost conn).

By default, it uses in-process dict (for dev is ok). Production instances should utilize REDIS and set REDIS_URI, IDEMPOTENCY_TTL_SECONDS (def 86400), LOCK_TTL_SECONDS (def 60s)

[Ref1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Idempotency-Key