### PR TITLE
Fix status api 404 on empty listings

### DIFF
--- a/app/routers/status/status.py
+++ b/app/routers/status/status.py
@@ -123,8 +123,6 @@ async def get_incidents(
         resource_id=resource_id,
         resolution=resolution,
     )
-    if not incidents:
-        raise HTTPException(status_code=404, detail="No incidents found")
     return incidents
 
 @router.get(
@@ -168,8 +166,6 @@ async def get_events(
     events = await router.adapter.get_events(
         incident_id=incident_id, offset=offset, limit=limit, resource_id=resource_id, name=name, description=description, status=status, from_=from_, to=to, time_=time_, modified_since=modified_since
     )
-    if not events:
-        raise HTTPException(status_code=404, detail="No events found")
     return events
 
 

--- a/app/routers/status/status.py
+++ b/app/routers/status/status.py
@@ -109,7 +109,7 @@ async def get_incidents(
         )
     ),
 ) -> list[models.Incident]:
-    incidents = await router.adapter.get_incidents(
+    return await router.adapter.get_incidents(
         offset=offset,
         limit=limit,
         name=name,
@@ -123,7 +123,7 @@ async def get_incidents(
         resource_id=resource_id,
         resolution=resolution,
     )
-    return incidents
+
 
 @router.get(
     "/incidents/{incident_id}",
@@ -163,10 +163,9 @@ async def get_events(
     limit: int = Query(default=100, ge=0, le=1000),
     _forbid=Depends(forbidExtraQueryParams("incident_id", "resource_id", "name", "description", "status", "from", "to", "time", "modified_since", "offset", "limit")),
 ) -> list[models.Event]:
-    events = await router.adapter.get_events(
+    return await router.adapter.get_events(
         incident_id=incident_id, offset=offset, limit=limit, resource_id=resource_id, name=name, description=description, status=status, from_=from_, to=to, time_=time_, modified_since=modified_since
     )
-    return events
 
 
 @router.get(


### PR DESCRIPTION
Resolves #109 

This PR makes the status api for incidents and events consistent with the other listing api calls in IRI by returning an empty array rather than throwing a 404 when there are no incidents or events to return.