### PR TITLE
Fix capability filter for resource listing

### DIFF
--- a/app/routers/status/facility_adapter.py
+++ b/app/routers/status/facility_adapter.py
@@ -23,7 +23,7 @@ class FacilityAdapter(ABC):
         modified_since: datetime.datetime | None = None,
         resource_type: status_models.ResourceTypeValue | None = None,
         current_status: status_models.Status | None = None,
-        capability: Capability | None = None,
+        capability: list[str] = [],
         site_id: str | None = None,
     ) -> list[status_models.Resource]:
         pass

--- a/app/routers/status/status.py
+++ b/app/routers/status/status.py
@@ -41,7 +41,7 @@ async def get_resources(
         examples=[models.ResourceType.compute, models.ResourceType.storage, models.ResourceType.storage_system, models.ResourceType.service],
     ),
     current_status: models.Status = Query(default=None),
-    capability: List[AllocationUnitValue] = Query(default=None, min_length=1),
+    capability: list[str] = Query(default=[], description="Capability ids to filter by. Including multiple capability ids returns any matches (logical OR not AND)."),
     _forbid=Depends(forbidExtraQueryParams("name", "description", "group", "offset", "limit", "modified_since", "resource_type", "current_status", "capability", multiParams={"capability"})),
 ) -> list[models.Resource]:
     return await router.adapter.get_resources(

--- a/app/routers/status/status.py
+++ b/app/routers/status/status.py
@@ -41,7 +41,7 @@ async def get_resources(
         examples=[models.ResourceType.compute, models.ResourceType.storage, models.ResourceType.storage_system, models.ResourceType.service],
     ),
     current_status: models.Status = Query(default=None),
-    capability: list[str] = Query(default=[], description="Capability ids to filter by. Including multiple capability ids returns any matches (logical OR not AND)."),
+    capability: list[str] | None = Query(default_factory=list, description="Capability ids to filter by. Including multiple capability ids returns any matches (logical OR not AND)."),
     _forbid=Depends(forbidExtraQueryParams("name", "description", "group", "offset", "limit", "modified_since", "resource_type", "current_status", "capability", multiParams={"capability"})),
 ) -> list[models.Resource]:
     return await router.adapter.get_resources(


### PR DESCRIPTION
Resolves #110 

The status api list resources call can filter by one ore more capability id. The static find method on `Resource` already implements an `any` reducer, so the documentation has been updated to describe the filter as a logical OR.

We could consider renaming the query parameter?

We will have to update the newly moved demo adapter code to implement the updated ABC signature for a list.