### PR TITLE
Truncate filesystem task logging

### DIFF
--- a/app/routers/task/facility_adapter.py
+++ b/app/routers/task/facility_adapter.py
@@ -43,9 +43,21 @@ class FacilityAdapter(AuthenticatedAdapter):
             else:
                 data = ind
             return {k: v for k, v in data.items() if v is not None}
+
+        def _sanitize_args(args):
+            if not isinstance(args, dict):
+                return args
+            sanitized = {}
+            for k, v in args.items():
+                if k == "content" and isinstance(v, str) and len(v) > 100:
+                    sanitized[k] = v[:100] + f"...<truncated {len(v) - 100} chars>"
+                else:
+                    sanitized[k] = v
+            return sanitized
+
         try:
             r = None
-            logger.info(f"Received task: {task.router}:{task.command} with args: {task.args}")
+            logger.info(f"Received task: {task.router}:{task.command} with args: {_sanitize_args(task.args)}")
             if task.router == "filesystem":
                 fs_adapter = IriRouter.create_adapter(task.router, filesystem_adapter.FacilityAdapter)
                 if task.command == "chmod":
@@ -106,6 +118,6 @@ class FacilityAdapter(AuthenticatedAdapter):
                 return ({"output": f"Task was cancelled due to unknown router/command: {task.router}:{task.command}"}, task_models.TaskStatus.failed)
         except Exception as exc:
             traceback_str = traceback.format_exc()
-            logger.warning(f"Error handling task {task.router}:{task.command} with args: {task.args}\nError: {exc}")
+            logger.warning(f"Error handling task {task.router}:{task.command} with args: {_sanitize_args(task.args)}\nError: {exc}")
             logger.debug(f"Traceback:\n{traceback_str}")
             return ({"output": f"Error: {exc}"}, task_models.TaskStatus.failed)


### PR DESCRIPTION
Resolves #111 

Sanitize the logging statements in the Task adapter that orchestrates Filesystem API calls. The arguments to the task system includes the contents of the files as base64 encoded strings. This fix simply truncates them so we don't fill up audit logs with useless (or worse, sensitive) data.

Could make the length limit configurable as a class variable or environment variable?