### PR TITLE
Add OTEL_SERVICE_NAME variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The API supports OpenTelemetry for distributed tracing and metrics. Traces and m
 | Variable | Default | Description |
 |---|---|---|
 | `OPENTELEMETRY_ENABLED` | `false` | Master switch. Must be `true` for any telemetry to be emitted. |
+| `OTEL_SERVICE_NAME` | `iri-facility-api` | The `service.name` resource attribute reported to the OTLP collector. |
 | `OTEL_TRACES_ENABLED` | `true` | Enable trace export. Only takes effect when `OPENTELEMETRY_ENABLED=true`. |
 | `OTEL_METRICS_ENABLED` | `true` | Enable metric export. Only takes effect when `OPENTELEMETRY_ENABLED=true`. |
 | `OTLP_ENDPOINT` | `""` | gRPC endpoint for the OTLP collector (e.g. `http://otel-collector:4317`). When empty, telemetry is printed to the console. |

--- a/app/config.py
+++ b/app/config.py
@@ -43,6 +43,7 @@ except Exception as exc:
 
 OPENTELEMETRY_ENABLED = os.environ.get("OPENTELEMETRY_ENABLED", "false").lower() == "true"
 OPENTELEMETRY_DEBUG = os.environ.get("OPENTELEMETRY_DEBUG", "false").lower() == "true"
+OTEL_SERVICE_NAME = os.environ.get("OTEL_SERVICE_NAME", "iri-facility-api")
 OTLP_ENDPOINT = os.environ.get("OTLP_ENDPOINT", "")
 OTEL_SAMPLE_RATE = float(os.environ.get("OTEL_SAMPLE_RATE", "0.2"))
 OTEL_TRACES_ENABLED = os.environ.get("OTEL_TRACES_ENABLED", "true").lower() == "true"
@@ -69,6 +70,7 @@ logger.info(f"LOG_LEVEL={LOG_LEVEL}")
 logger.info(f"OPENTELEMETRY_ENABLED={OPENTELEMETRY_ENABLED}")
 logger.info(f"OPENTELEMETRY_DEBUG={OPENTELEMETRY_DEBUG}")
 logger.info(f"OTLP_ENDPOINT={OTLP_ENDPOINT}")
+logger.info(f"OTEL_SERVICE_NAME={OTEL_SERVICE_NAME}")
 logger.info(f"OTEL_SAMPLE_RATE={OTEL_SAMPLE_RATE}")
 logger.info(f"OTEL_TRACES_ENABLED={OTEL_TRACES_ENABLED}")
 logger.info(f"OTEL_METRICS_ENABLED={OTEL_METRICS_ENABLED}")

--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,7 @@ configure_logging(config.LOG_LEVEL)
 # OpenTelemetry Configuration
 # ------------------------------------------------------------------
 if config.OPENTELEMETRY_ENABLED:
-    resource = Resource.create({"service.name": "iri-facility-api", "service.version": config.API_VERSION, "service.endpoint": config.API_URL_ROOT})
+    resource = Resource.create({"service.name": config.OTEL_SERVICE_NAME, "service.version": config.API_VERSION, "service.endpoint": config.API_URL_ROOT})
 
     if config.OTEL_TRACES_ENABLED:
         samplerate = "1.0" if config.OPENTELEMETRY_DEBUG else config.OTEL_SAMPLE_RATE


### PR DESCRIPTION
I have multiple IRI deployments that I want connect to a central collector. Being able to modify the `service.name` should help with that, the rest of the OTEL works in testing.